### PR TITLE
New option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ stack install
 
 ## How to use it
 
-TODO
-
 1. Write some repo URLs to an `.elm-smuggle`. Commit this file.
 2. Run `elm-smuggle` from the project root.
 3. Run `elm install <smuggled-package-name>`
@@ -30,13 +28,24 @@ TODO
 ## Options
 
 ```
--v, --version      Print elm-smuggle version
--h, --help         Print help information
+-v, --version       Print elm-smuggle version
+```
 
---suppress-errors  Don't print (non-fatal) errors
---reinstall        Force reinstall package versions
+```
+-h, --help          Print help information
+```
 
---local-bin        Use elm binary from node_modules dir
+```
+--suppress-errors   Don't print (non-fatal) errors
+```
+
+```
+--reinstall         Force reinstall package versions
+```
+
+By default `elm-smuggle` will use system installation of `elm 0.19`.
+```
+--elm-bin=<path>    Relative path to elm binary, e.g. to the one in your node_modules folder
 ```
 
 ## Caveats
@@ -52,4 +61,3 @@ Packages to be smuggled _should_ be publishable by `elm` standards. That means:
 ## TODO
 
 -   [ ] Rethink `.elm-smuggle` file format
--   [ ] Rethink `--local-bin` flag

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ TODO
 2. Run `elm-smuggle` from the project root.
 3. Run `elm install <smuggled-package-name>`
 
+## Options
+
+```
+-v, --version      Print elm-smuggle version
+-h, --help         Print help information
+
+--suppress-errors  Don't print (non-fatal) errors
+--reinstall        Force reinstall package versions
+
+--local-bin        Use elm binary from node_modules dir
+```
+
 ## Caveats
 
 Packages to be smuggled _should_ be publishable by `elm` standards. That means:
@@ -40,3 +52,4 @@ Packages to be smuggled _should_ be publishable by `elm` standards. That means:
 ## TODO
 
 -   [ ] Rethink `.elm-smuggle` file format
+-   [ ] Rethink `--local-bin` flag

--- a/elm-smuggle.cabal
+++ b/elm-smuggle.cabal
@@ -1,5 +1,5 @@
 name: elm-smuggle
-version: 0.6.0
+version: 0.6.1
 synopsis: Smuggle git dependencies into your Elm apps
 description:
     Add git dependencies to Elm 0.19 applications.
@@ -53,6 +53,7 @@ executable elm-smuggle
       , binary               >= 0.8.5 && < 0.9
       , bytestring           >= 0.10.8 && < 0.11
       , containers           >= 0.5.11 && < 0.6
+      , directory            >= 1.3 && < 2
       , exceptions           >= 0.10.0 && < 0.11
       , network-uri          >= 2.6.1 && < 2.7
       , path                 >= 0.6.1 && < 0.7

--- a/elm-smuggle.cabal
+++ b/elm-smuggle.cabal
@@ -1,5 +1,5 @@
 name: elm-smuggle
-version: 0.5.0
+version: 0.6.0
 synopsis: Smuggle git dependencies into your Elm apps
 description:
     Add git dependencies to Elm 0.19 applications.
@@ -46,7 +46,7 @@ executable elm-smuggle
         Git
         Paths_elm_smuggle
     build-depends:
-        base                 >= 4.11   && < 4.12
+        base                 >= 4.11   && < 5
       , aeson                >= 1.3.1 && < 1.4
       , ansi-terminal        >= 0.8.1 && < 0.9
       , async                >= 2.2.1 && < 2.3

--- a/elm-smuggle/Command.hs
+++ b/elm-smuggle/Command.hs
@@ -33,8 +33,12 @@ which :: MonadIO m => Path Rel File -> m (Maybe Command)
 which = fmap (fmap Command) . Path.IO.findExecutable
 
 
-whichFind :: MonadIO m => [Path b Dir] -> Path Rel File -> m (Maybe Command)
-whichFind dirs = fmap (fmap Command) . Path.IO.findFile dirs
+resolve :: MonadIO m  => IO.FilePath -> m (Maybe Command)
+resolve = fmap (fmap Command) . fmap Maybe . Path.IO.resolveFile'
+
+
+-- whichFind :: MonadIO m => [Path b Dir] -> Path Rel File -> m (Maybe Command)
+-- whichFind dirs = fmap (fmap Command) . Path.IO.findFile dirs
 
 
 data Result = Result

--- a/elm-smuggle/Command.hs
+++ b/elm-smuggle/Command.hs
@@ -2,6 +2,7 @@
 module Command
     ( Command
     , which
+    , whichFind
     , run
     , runWithYes
     , Result
@@ -22,7 +23,7 @@ import qualified System.Process as Process
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Path (Abs, File, Path, Rel)
+import Path (Abs, File, Dir, Path, Rel)
 
 
 newtype Command = Command { _commandPath :: Path Abs File }
@@ -30,6 +31,10 @@ newtype Command = Command { _commandPath :: Path Abs File }
 
 which :: MonadIO m => Path Rel File -> m (Maybe Command)
 which = fmap (fmap Command) . Path.IO.findExecutable
+
+
+whichFind :: MonadIO m => [Path b Dir] -> Path Rel File -> m (Maybe Command)
+whichFind dirs = fmap (fmap Command) . Path.IO.findFile dirs
 
 
 data Result = Result

--- a/elm-smuggle/Command.hs
+++ b/elm-smuggle/Command.hs
@@ -2,7 +2,7 @@
 module Command
     ( Command
     , which
-    , whichFind
+    , resolve
     , run
     , runWithYes
     , Result
@@ -19,11 +19,12 @@ import qualified Path.IO
 import qualified System.Exit as Exit
 import qualified System.IO as IO
 import qualified System.Process as Process
+import qualified System.Directory as Directory
 
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Path (Abs, File, Dir, Path, Rel)
+import Path (Abs, File, Path, Rel)
 
 
 newtype Command = Command { _commandPath :: Path Abs File }
@@ -34,11 +35,13 @@ which = fmap (fmap Command) . Path.IO.findExecutable
 
 
 resolve :: MonadIO m  => IO.FilePath -> m (Maybe Command)
-resolve = fmap (fmap Command) . fmap Maybe . Path.IO.resolveFile'
-
-
--- whichFind :: MonadIO m => [Path b Dir] -> Path Rel File -> m (Maybe Command)
--- whichFind dirs = fmap (fmap Command) . Path.IO.findFile dirs
+resolve elmBinPath = liftIO $ do
+    fileExists <- Directory.doesFileExist elmBinPath
+    fmap (fmap Command) $ 
+        if fileExists then
+            fmap Just $ Path.IO.resolveFile' elmBinPath
+        else
+            pure Nothing
 
 
 data Result = Result

--- a/elm-smuggle/Elm.hs
+++ b/elm-smuggle/Elm.hs
@@ -91,8 +91,9 @@ import Text.Read (readMaybe)
 newtype Command = Command { _unwrapCommand :: Command.Command }
 
 
-command :: MonadIO m => m (Maybe Command)
-command = fmap Command <$> Command.which $(Path.mkRelFile "elm")
+command :: MonadIO m => Bool -> m (Maybe Command)
+command False = fmap Command <$> Command.which $(Path.mkRelFile "elm")
+command True = fmap Command <$> Command.whichFind [$(Path.mkRelDir "node_modules/.bin")] $(Path.mkRelFile "elm")
 
 
 -- NOTE: Running this may require package downloads!

--- a/elm-smuggle/Elm.hs
+++ b/elm-smuggle/Elm.hs
@@ -91,9 +91,17 @@ import Text.Read (readMaybe)
 newtype Command = Command { _unwrapCommand :: Command.Command }
 
 
-command :: MonadIO m => Bool -> m (Maybe Command)
-command False = fmap Command <$> Command.which $(Path.mkRelFile "elm")
-command True = fmap Command <$> Command.whichFind [$(Path.mkRelDir "node_modules/.bin")] $(Path.mkRelFile "elm")
+command :: MonadIO m => Maybe String -> m (Maybe Command)
+command Nothing = fmap Command <$> Command.which $(Path.mkRelFile "elm")
+command (Just binPath) = fmap Command <$> Command.resolve binPath
+
+--command (Just binPath) = fmap Command <$> Command.whichFind [$(Path.mkRelDir "./node_modules/elm/unpacked_bin/")] elmBin
+
+-- elmBin :: Path Rel File
+-- elmBin = $(Path.mkRelFile "elm.exe")
+
+-- elmSearchDirs :: [Path Rel Dir]
+-- elmSearchDirs = [ $(Path.mkRelDir "./node_modules/elm/unpacked_bin/") ]
 
 
 -- NOTE: Running this may require package downloads!

--- a/elm-smuggle/Elm.hs
+++ b/elm-smuggle/Elm.hs
@@ -95,14 +95,6 @@ command :: MonadIO m => Maybe String -> m (Maybe Command)
 command Nothing = fmap Command <$> Command.which $(Path.mkRelFile "elm")
 command (Just binPath) = fmap Command <$> Command.resolve binPath
 
---command (Just binPath) = fmap Command <$> Command.whichFind [$(Path.mkRelDir "./node_modules/elm/unpacked_bin/")] elmBin
-
--- elmBin :: Path Rel File
--- elmBin = $(Path.mkRelFile "elm.exe")
-
--- elmSearchDirs :: [Path Rel Dir]
--- elmSearchDirs = [ $(Path.mkRelDir "./node_modules/elm/unpacked_bin/") ]
-
 
 -- NOTE: Running this may require package downloads!
 makeDocs :: (MonadIO m, MonadCatch m) => Command -> m Command.Result

--- a/elm-smuggle/Main.hs
+++ b/elm-smuggle/Main.hs
@@ -26,6 +26,7 @@ import qualified System.Console.ANSI as ANSI
 import qualified System.Exit as Exit
 import qualified System.Info
 import qualified System.IO as IO
+--import qualified Common as C
 
 import Control.Monad (guard, unless, void, when)
 import Data.Bifunctor (bimap)
@@ -34,7 +35,7 @@ import Data.Map (Map)
 import Data.Maybe (mapMaybe)
 import Data.String (IsString)
 import Data.Text (Text)
-import Options (Options(..))
+import Options (Options(..), localBin)
 import Path (Abs, Dir, Path, (</>))
 
 
@@ -53,7 +54,7 @@ main = do
         Just cmd -> pure cmd
         Nothing  -> failure "git not found"
 
-    elm <- Elm.command >>= \case
+    elm <- Elm.command (localBin opts) >>= \case
         Just cmd -> pure cmd
         Nothing  -> failure "elm not found"
 

--- a/elm-smuggle/Main.hs
+++ b/elm-smuggle/Main.hs
@@ -35,7 +35,7 @@ import Data.Map (Map)
 import Data.Maybe (mapMaybe)
 import Data.String (IsString)
 import Data.Text (Text)
-import Options (Options(..), localBin)
+import Options (Options(..), elmBin)
 import Path (Abs, Dir, Path, (</>))
 
 
@@ -54,7 +54,7 @@ main = do
         Just cmd -> pure cmd
         Nothing  -> failure "git not found"
 
-    elm <- Elm.command (localBin opts) >>= \case
+    elm <- Elm.command (elmBin opts) >>= \case
         Just cmd -> pure cmd
         Nothing  -> failure "elm not found"
 
@@ -62,25 +62,25 @@ main = do
         Elm.Elm019 -> pure ()
         Elm.Elm018 -> failure "need elm 0.19"
 
-    --     Elm.UnknownCompilerVersion version ->
-    --         failure ("unknown compiler version: " <> Text.pack version)
+        Elm.UnknownCompilerVersion version ->
+            failure ("unknown compiler version: " <> Text.pack version)
 
-    -- TextIO.putStrLn "Starting downloads...\n"
-    -- msgChan     <- Concurrent.newChan
+    TextIO.putStrLn "Starting downloads...\n"
+    msgChan     <- Concurrent.newChan
 
-    -- installed <- Path.IO.withSystemTempDir "elm-smuggle" $ \tmpDir -> do
-    --     cacheDir <- Elm.packageCacheDir
-    --     void . Concurrent.forkIO $
-    --         downloadProjects msgChan opts git elm cacheDir tmpDir
-    --     installProjects msgChan opts cacheDir
+    installed <- Path.IO.withSystemTempDir "elm-smuggle" $ \tmpDir -> do
+        cacheDir <- Elm.packageCacheDir
+        void . Concurrent.forkIO $
+            downloadProjects msgChan opts git elm cacheDir tmpDir
+        installProjects msgChan opts cacheDir
 
-    -- currentRegistry <- readElmPackageRegistry >>= \case
-    --     Right registry -> pure registry
-    --     Left  err      ->
-    --         failure ("couldn't read existing package registry\n" <> Text.pack err)
+    currentRegistry <- readElmPackageRegistry >>= \case
+        Right registry -> pure registry
+        Left  err      ->
+            failure ("couldn't read existing package registry\n" <> Text.pack err)
 
-    -- let newRegistry = smugglePackages installed currentRegistry
-    -- writeElmPackageRegistry newRegistry
+    let newRegistry = smugglePackages installed currentRegistry
+    writeElmPackageRegistry newRegistry
     TextIO.putStrLn "\nDependencies ready!"
   where
     failure :: Text -> IO a

--- a/elm-smuggle/Main.hs
+++ b/elm-smuggle/Main.hs
@@ -62,25 +62,25 @@ main = do
         Elm.Elm019 -> pure ()
         Elm.Elm018 -> failure "need elm 0.19"
 
-        Elm.UnknownCompilerVersion version ->
-            failure ("unknown compiler version: " <> Text.pack version)
+    --     Elm.UnknownCompilerVersion version ->
+    --         failure ("unknown compiler version: " <> Text.pack version)
 
-    TextIO.putStrLn "Starting downloads...\n"
-    msgChan     <- Concurrent.newChan
+    -- TextIO.putStrLn "Starting downloads...\n"
+    -- msgChan     <- Concurrent.newChan
 
-    installed <- Path.IO.withSystemTempDir "elm-smuggle" $ \tmpDir -> do
-        cacheDir <- Elm.packageCacheDir
-        void . Concurrent.forkIO $
-            downloadProjects msgChan opts git elm cacheDir tmpDir
-        installProjects msgChan opts cacheDir
+    -- installed <- Path.IO.withSystemTempDir "elm-smuggle" $ \tmpDir -> do
+    --     cacheDir <- Elm.packageCacheDir
+    --     void . Concurrent.forkIO $
+    --         downloadProjects msgChan opts git elm cacheDir tmpDir
+    --     installProjects msgChan opts cacheDir
 
-    currentRegistry <- readElmPackageRegistry >>= \case
-        Right registry -> pure registry
-        Left  err      ->
-            failure ("couldn't read existing package registry\n" <> Text.pack err)
+    -- currentRegistry <- readElmPackageRegistry >>= \case
+    --     Right registry -> pure registry
+    --     Left  err      ->
+    --         failure ("couldn't read existing package registry\n" <> Text.pack err)
 
-    let newRegistry = smugglePackages installed currentRegistry
-    writeElmPackageRegistry newRegistry
+    -- let newRegistry = smugglePackages installed currentRegistry
+    -- writeElmPackageRegistry newRegistry
     TextIO.putStrLn "\nDependencies ready!"
   where
     failure :: Text -> IO a

--- a/usage.txt
+++ b/usage.txt
@@ -4,13 +4,13 @@ USAGE
     elm-smuggle [OPTIONS] [URLS]
 
 OPTIONS
-    -v, --version      Print elm-smuggle version
-    -h, --help         Print help information
+    -v, --version       Print elm-smuggle version
+    -h, --help          Print help information
 
-    --suppress-errors  Don't print (non-fatal) errors
-    --reinstall        Force reinstall package versions
+    --suppress-errors   Don't print (non-fatal) errors
+    --reinstall         Force reinstall package versions
 
-    --local-bin        Use elm binary from node_modules dir
+    --elm-bin=<path>    Relative path to elm binary, e.g. to the one in your node_modules folder
 
 URLS
 
@@ -35,4 +35,4 @@ DOTFILE
         file:///home/me/elm/projects/another-thing
 
 
-See <https://github.com/jmackie/elm-smuggle#readme> for more info.
+See <https://github.com/ivan-jukic/elm-smuggle#readme> for more info.

--- a/usage.txt
+++ b/usage.txt
@@ -10,6 +10,8 @@ OPTIONS
     --suppress-errors  Don't print (non-fatal) errors
     --reinstall        Force reinstall package versions
 
+    --local-bin        Use elm binary from node_modules dir
+
 URLS
 
     Git repository urls to be passed to `git clone`. For example:


### PR DESCRIPTION
Hey @jmackie , hope all is good :)

I've made a small change on the `elm-smuggle`. I've added a new argument option `--elm-bin` which is for the purpose of passing a relative path to the elm binary that we want to use, instead of relying on the system wide elm installation. So if you have for e.g. 0.18 installed on the system, but have included 0.19 in your `packages.json`, you can now tell `elm-smuggle` here's the elm binary.

Tested it on Win and Linux, compiles and seems to be working. Please check my Haskell code, if it's at all close to your standards, and let me know what I need to fix.

Hopefully, if it's all good, we could update `elm-smuggle` on the NPM as well.

Thanks!